### PR TITLE
Update nokogiri to 1.8

### DIFF
--- a/imgin.gemspec
+++ b/imgin.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency "nokogiri",
-    ["= 1.6.1"]
+    ["~> 1.8"]
   s.add_runtime_dependency "rspec",
     ["= 2.14.1"]
 end


### PR DESCRIPTION
Hi,

This gem is stuck at nokogiri 1.6 which is annoying for all projects depending on it as there is a security issue on Nokogiri < 1.8.
So that PR is simply upgrading nokogiri's version.